### PR TITLE
Update dependencies and docs for venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ The dashboard lives under `streamlit_app/` and can be run either locally or via 
 
 ### Local Python execution
 
-Install the dependencies and start Streamlit:
+Install the dependencies in a virtual environment and start Streamlit:
 
 ```bash
+python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 streamlit run streamlit_app/app.py
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 streamlit>=1.28
 pydeck>=0.8
 pandas>=1.5
-pgeocode>=0.3
+pgeocode==0.4.1


### PR DESCRIPTION
## Summary
- pin `pgeocode` to `0.4.1` in `requirements.txt`
- recommend creating a virtual environment before installing dependencies in the README

## Testing
- `python3 -m pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6876c9265f5883229030f39e14cd3966