### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ishan Yash
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ streamlit run streamlit_app/app.py
 - `dataset*.csv` – data used during the analysis
 
 The dataset used in the dashboard is located at `streamlit_app/data/investment_analysis_phase3.csv`.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -23,13 +23,17 @@ filtered = df[df['region'].isin(selected_regions) & df['yield_category'].isin(se
 
 # Map layer color based on yield category
 color_map = {
-    'Very High': [0, 128, 0],
-    'High': [34, 139, 34],
-    'Medium': [255, 165, 0],
-    'Low': [255, 0, 0]
+    "Very High": [0, 128, 0],
+    "High": [34, 139, 34],
+    "Medium": [255, 165, 0],
+    "Low": [255, 0, 0],
 }
 
-filtered['color'] = filtered['yield_category'].map(color_map).fillna([200, 200, 200])
+# Map yield categories to colors and use a grey default for any unmapped
+# values. Using dict.get avoids errors with fillna expecting scalar values.
+filtered["color"] = filtered["yield_category"].apply(
+    lambda cat: color_map.get(cat, [200, 200, 200])
+)
 
 layer = pdk.Layer(
     "ScatterplotLayer",


### PR DESCRIPTION
## Summary
- add an MIT LICENSE file
- document the license in the README
- fix streamlit color-mapping bug by avoiding `fillna` on lists

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6876c92865108322968c64469d43c50c